### PR TITLE
Use environment markers for setuptools version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,6 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info.major < 3:
-    stools = 'setuptools<=42.0.2'
-else:
-    stools = 'setuptools'
-
 # Utility function to read the README file.
 # Used for the long_description.  It's nice, because now 1) we have a top level
 # README file and 2) it's easier to type in the README file than to put a raw
@@ -44,7 +39,8 @@ setup(
     python_requires='>=2.7',
     install_requires=[
         'requests[security]>=2.0',
-        stools,
+        'setuptools<=42.0.2; python_version <= "2.7"',
+        'setuptools; python_version >= "3.4"',
         'six>=1.9',
     ]
 )


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Здравствуйте!

Poetry некорректно резолвит версию setuptools для python3: используется <=42.0.2 вместо без ограничений

Кусочек лога резолвера:

```
Source (PyPI): 27 packages found for six *
   3: selecting six (1.16.0)
   3: selecting pluggy (1.4.0)
   3: selecting frozenlist (1.4.1)
   3: fact: yandex-tracker-client (2.6) depends on requests (>=2.0)
   3: fact: yandex-tracker-client (2.6) depends on setuptools (<=42.0.2)
   3: fact: yandex-tracker-client (2.6) depends on six (>=1.9)
   3: selecting yandex-tracker-client (2.6)
   3: derived: setuptools (<=42.0.2)
   3: derived: requests[security] (>=2.0)
```

Им заводили issue, на что был получен ответ использовать environment markers: https://github.com/python-poetry/poetry/issues/758#issuecomment-453864964

Я заменил if на environment markers в блоке install_requires.